### PR TITLE
style: use index insert to map, add _ member variable front

### DIFF
--- a/cpp_module00/Warlock.hpp
+++ b/cpp_module00/Warlock.hpp
@@ -6,33 +6,32 @@
 using namespace std;
 
 class Warlock {
-private:
-	string name;
-	string title;
-
-public:
-	Warlock(const string &name, const string &title) : name(name), title(title) {
-		cout << name << ": This looks like another boring day." << endl;
+ public:
+	Warlock(const string &name, const string &title) : _name(name), _title(title) {
+		cout << _name << ": This looks like another boring day." << endl;
 	}
 
 	~Warlock() {
-		cout << name << ": My job here is done!" << endl;
+		cout << _name << ": My job here is done!" << endl;
 	}
 
 	const string &getName() const {
-		return name;
+		return _name;
 	}
 
 	const string &getTitle() const {
-		return title;
+		return _title;
 	}
 
 	void setTitle(const string &title) {
-		this->title = title;
+		_title = title;
 	}
 
 	void introduce() const {
-		cout << name << ": I am " << name << ", " << title << "!" << endl; 
+		cout << _name << ": I am " << _name << ", " << _title << "!" << endl;
 	}
-};
 
+ private:
+	string _name;
+	string _title;
+};

--- a/cpp_module01/ASpell.hpp
+++ b/cpp_module01/ASpell.hpp
@@ -7,24 +7,24 @@ using namespace std;
 class ATarget;
 
 class ASpell {
-private:
-	string name;
-	string effects;
-
-public:
-	ASpell(const string &name, const string &effects) : name(name), effects(effects) {}
+ public:
+	ASpell(const string &name, const string &effects) : _name(name), _effects(effects) {}
 
 	virtual ~ASpell() {}
 
 	const string &getName() const {
-		return name;
+		return _name;
 	}
 
 	const string &getEffects() const {
-		return effects;
+		return _effects;
 	}
 
 	virtual ASpell *clone() const = 0;
 
 	void launch(const ATarget &target) const;
+
+ private:
+	string _name;
+	string _effects;
 };

--- a/cpp_module01/ATarget.cpp
+++ b/cpp_module01/ATarget.cpp
@@ -1,5 +1,5 @@
 #include "ATarget.hpp"
 
 void ATarget::getHitBySpell(const ASpell &spell) const {
-	cout << type << " has been " << spell.getEffects() << "!" << endl;
+	cout << _type << " has been " << spell.getEffects() << "!" << endl;
 }

--- a/cpp_module01/ATarget.hpp
+++ b/cpp_module01/ATarget.hpp
@@ -9,19 +9,19 @@ using namespace std;
 class ASpell;
 
 class ATarget {
-private:
-	string type;
+ public:
+	ATarget(const string &type) : _type(type) {}
 
-public:
-	ATarget(const string &type) : type(type) {}
-
-	~ATarget() {}
+	virtual ~ATarget() {}
 
 	const string &getType() const {
-		return type;
+		return _type;
 	}
 
 	virtual ATarget *clone() const = 0;
 
 	void getHitBySpell(const ASpell &spell) const;
+
+ private:
+	string _type;
 };

--- a/cpp_module01/Dummy.hpp
+++ b/cpp_module01/Dummy.hpp
@@ -5,7 +5,7 @@
 class ATarget;
 
 class Dummy : public ATarget {
-public:
+ public:
 	Dummy() : ATarget("Target Practice Dummy") {}
 
 	~Dummy() {}

--- a/cpp_module01/Fwoosh.hpp
+++ b/cpp_module01/Fwoosh.hpp
@@ -3,7 +3,7 @@
 #include "ASpell.hpp"
 
 class Fwoosh : public ASpell {
-public:
+ public:
 	Fwoosh() : ASpell("Fwoosh", "fwooshed") {}
 
 	~Fwoosh() {}

--- a/cpp_module01/Warlock.hpp
+++ b/cpp_module01/Warlock.hpp
@@ -8,48 +8,50 @@
 using namespace std;
 
 class Warlock {
-private:
-	string name;
-	string title;
-	map<string, ASpell *> spellBook;
- 
-public:
-	Warlock(const string &name, const string &title) : name (name), title(title) {
-		cout << name << ": This looks like another boring day." << endl;
+ public:
+	Warlock(const string &name, const string &title) : _name(name), _title(title) {
+		cout << _name << ": This looks like another boring day." << endl;
 	}
 
 	~Warlock() {
-		cout << name << ": My job here is done!" << endl;
+		cout << _name << ": My job here is done!" << endl;
 	}
 
 	const string &getName() const {
-		return name;
+		return _name;
 	}
 
 	const string &getTitle() const {
-		return title;
+		return _title;
 	}
 
 	void setTitle(const string &title) {
-		this->title = title;
+		_title = title;
 	}
 
 	void introduce() const {
-		cout << name << ": I am " << name << ", " << title << "!" << endl;
+		cout << _name << ": I am " << _name << ", " << _title << "!" << endl;
 	}
 
 	void learnSpell(ASpell *spell) {
 		if (spell)
-			spellBook.insert(make_pair(spell->getName(), spell->clone()));
+            _spellBook[spell->getName()] = spell->clone();
 	}
 
 	void forgetSpell(const string &spellName) {
-		if (spellBook.find(spellName) != spellBook.end())
-			spellBook.erase(spellBook.find(spellName));
+        auto it = _spellBook.find(spellName);
+        if (it != _spellBook.end())
+            _spellBook.erase(it);
 	}
 
 	void launchSpell(const string &spellName, const ATarget &target) {
-		if (spellBook.find(spellName) != spellBook.end())
-			spellBook[spellName]->launch(target);
+		auto it = _spellBook.find(spellName);
+		if (it != _spellBook.end())
+			it->second->launch(target);
 	}
+
+ private:
+	string _name;
+	string _title;
+	map<string, ASpell *> _spellBook;
 };

--- a/cpp_module02/ASpell.hpp
+++ b/cpp_module02/ASpell.hpp
@@ -7,24 +7,24 @@ using namespace std;
 class ATarget;
 
 class ASpell {
-private:
-	string name;
-	string effects;
-public:
-	ASpell(const string &name, const string &effects) : name(name), effects(effects) {}
+ public:
+	ASpell(const string &name, const string &effects) : _name(name), _effects(effects) {}
 
-	~ASpell() {}
+	virtual ~ASpell() {}
 
 	const string &getName() const {
-		return name;
+		return _name;
 	}
 
 	const string &getEffects() const {
-		return effects;
+		return _effects;
 	}
-
 
 	virtual ASpell *clone() const = 0;
 
 	void launch(const ATarget &target) const;
+
+ private:
+	string _name;
+	string _effects;
 };

--- a/cpp_module02/ATarget.cpp
+++ b/cpp_module02/ATarget.cpp
@@ -1,5 +1,5 @@
 #include "ATarget.hpp"
 
 void ATarget::getHitBySpell(const ASpell &spell) const {
-	cout << type << " has been " << spell.getEffects() << "!" << endl;
+	cout << _type << " has been " << spell.getEffects() << "!" << endl;
 }

--- a/cpp_module02/ATarget.hpp
+++ b/cpp_module02/ATarget.hpp
@@ -9,19 +9,19 @@ using namespace std;
 class ASpell;
 
 class ATarget {
-private:
-	string type;
+ public:
+	ATarget(const string &type) : _type(type) {}
 
-public:
-	ATarget(const string &type) : type(type) {}
-
-	~ATarget() {}
+	virtual ~ATarget() {}
 
 	const string &getType() const {
-		return type;
+		return _type;
 	}
 
 	virtual ATarget *clone() const = 0;
 
 	void getHitBySpell(const ASpell &spell) const;
+
+ private:
+	string _type;
 };

--- a/cpp_module02/BrickWall.hpp
+++ b/cpp_module02/BrickWall.hpp
@@ -5,7 +5,7 @@
 class ATarget;
 
 class BrickWall : public ATarget {
-public:
+ public:
 	BrickWall() : ATarget("Inconspicuous Red-brick Wall") {}
 
 	~BrickWall() {}

--- a/cpp_module02/Dummy.hpp
+++ b/cpp_module02/Dummy.hpp
@@ -5,7 +5,7 @@
 class ATarget;
 
 class Dummy : public ATarget {
-public:
+ public:
 	Dummy() : ATarget("Target Practice Dummy") {}
 
 	~Dummy() {}

--- a/cpp_module02/Fireball.hpp
+++ b/cpp_module02/Fireball.hpp
@@ -3,10 +3,10 @@
 #include "ASpell.hpp"
 
 class Fireball : public ASpell {
-public:
+ public:
 	Fireball() : ASpell("Fireball", "burnt to a crisp") {}
 
-	virtual ~Fireball() {}
+	~Fireball() {}
 
 	ASpell *clone() const {
 		return new Fireball();

--- a/cpp_module02/Fwoosh.hpp
+++ b/cpp_module02/Fwoosh.hpp
@@ -3,7 +3,7 @@
 #include "ASpell.hpp"
 
 class Fwoosh : public ASpell {
-public:
+ public:
 	Fwoosh() : ASpell("Fwoosh", "fwooshed") {}
 
 	~Fwoosh() {}

--- a/cpp_module02/Polymorph.hpp
+++ b/cpp_module02/Polymorph.hpp
@@ -3,10 +3,10 @@
 #include "ASpell.hpp"
 
 class Polymorph : public ASpell {
-public:
+ public:
 	Polymorph() : ASpell("Polymorph", "turned into a critter") {}
 
-	virtual ~Polymorph() {}
+	~Polymorph() {}
 
 	ASpell *clone() const {
 		return new Polymorph();

--- a/cpp_module02/SpellBook.hpp
+++ b/cpp_module02/SpellBook.hpp
@@ -3,28 +3,30 @@
 #include "ASpell.hpp"
 
 class SpellBook {
-private:
-	map<string, ASpell *> spellBook;
- 
-public:
+ public:
 	SpellBook() {}
 
 	~SpellBook() {}
 
 	void learnSpell(ASpell *spell) {
 		if (spell)
-			spellBook.insert(make_pair(spell->getName(), spell->clone()));
+			_spellBook[spell->getName()] = spell->clone();
 	}
 
 	void forgetSpell(const string &spellName) {
-		if (spellBook.find(spellName) != spellBook.end())
-			spellBook.erase(spellBook.find(spellName));
+        auto it = _spellBook.find(spellName);
+        if (it != _spellBook.end())
+            _spellBook.erase(it);
 	}
 
 	ASpell* createSpell(string const &spellName) {
 		ASpell *tmp = NULL;
-		if (spellBook.find(spellName) != spellBook.end())
-			tmp = spellBook[spellName];
+		auto it = _spellBook.find(spellName);
+		if (it != _spellBook.end())
+			tmp = it->second;
 		return tmp;
 	}
+
+ private:
+	map<string, ASpell *> _spellBook;
 };

--- a/cpp_module02/TargetGenerator.hpp
+++ b/cpp_module02/TargetGenerator.hpp
@@ -3,28 +3,30 @@
 #include "ATarget.hpp"
 
 class TargetGenerator {
-private:
-	map<string, ATarget *> targetBook;
- 
-public:
+ public:
 	TargetGenerator() {}
 
 	~TargetGenerator() {}
 
 	void learnTargetType(ATarget *target) {
 		if (target)
-			targetBook.insert(make_pair(target->getType(), target->clone()));
+            _targetBook[target->getType()] = target->clone();
 	}
 
 	void forgetTarget(const string &targetType) {
-		if (targetBook.find(targetType) != targetBook.end())
-			targetBook.erase(targetBook.find(targetType));
+        auto it = _targetBook.find(targetType);
+        if (it != _targetBook.end())
+            _targetBook.erase(it);
 	}
 
 	ATarget* createTarget(string const &targetType) {
 		ATarget *tmp = NULL;
-		if (targetBook.find(targetType) != targetBook.end())
-			tmp = targetBook[targetType];
+		auto it = _targetBook.find(targetType);
+		if (it != _targetBook.end())
+			tmp = it->second;
 		return tmp;
 	}
+
+ private:
+	map<string, ATarget *> _targetBook;
 };

--- a/cpp_module02/Warlock.hpp
+++ b/cpp_module02/Warlock.hpp
@@ -7,48 +7,48 @@
 using namespace std;
 
 class Warlock {
-private:
-	string name;
-	string title;
-	SpellBook spellBook;
- 
-public:
-	Warlock(const string &name, const string &title) : name (name), title(title) {
-		cout << name << ": This looks like another boring day." << endl;
+ public:
+	Warlock(const string &name, const string &title) : _name(name), _title(title) {
+		cout << _name << ": This looks like another boring day." << endl;
 	}
 
 	~Warlock() {
-		cout << name << ": My job here is done!" << endl;
+		cout << _name << ": My job here is done!" << endl;
 	}
 
 	const string &getName() const {
-		return name;
+		return _name;
 	}
 
 	const string &getTitle() const {
-		return title;
+		return _title;
 	}
 
 	void setTitle(const string &title) {
-		this->title = title;
+		_title = title;
 	}
 
 	void introduce() const {
-		cout << name << ": I am " << name << ", " << title << "!" << endl;
+		cout << _name << ": I am " << _name << ", " << _title << "!" << endl;
 	}
 
 	void learnSpell(ASpell *spell) {
 		if (spell)
-			spellBook.learnSpell(spell);
+			_spellBook.learnSpell(spell);
 	}
 
 	void forgetSpell(const string &spellName) {
-		spellBook.forgetSpell(spellName);
+		_spellBook.forgetSpell(spellName);
 	}
 
 	void launchSpell(const string &spellName, const ATarget &target) {
-		ASpell *tmp = spellBook.createSpell(spellName);
-		if (tmp)
-			tmp->launch(target);
+		ASpell *spell = _spellBook.createSpell(spellName);
+		if (spell)
+			spell->launch(target);
 	}
+
+ private:
+	string _name;
+	string _title;
+	SpellBook _spellBook;
 };


### PR DESCRIPTION
- privateメンバは下に移動させました。個人的な好みです。
- privateメンバ変数には前方に_をつけた
  - this->name = nameが_name = nameで良くなる(トータルでは記述が多くなるかも。ただ混乱しなくなると思う)
- 基底クラスにvirtualがついていないものに追加し、派生クラスでついていた場合は削除した
  - 今回の課題ではメンバ変数にallocateしたものを保持してそれをdeleteするなどの処理がないため全て必要ないかも知れない。
  - 保証はできないのと、つけておく癖があったほうが良い方に転ぶのでつけた
- map insertの方法の変更
```
spellBook.insert(make_pair(spell->getName(), spell->clone()); //旧
_spellBook[spell->getName()] = spell->clone(); //新
```
- autoの使用
  - 可能であれば `delete it->second` とかを使うとリークがなくなると思う
```
void forgetSpell(const string &spellName) {
	if (spellBook.find(spellName) != spellBook.end())
		spellBook.erase(spellBook.find(spellName));
}

void forgetSpell(const string &spellName) {
        auto it = _spellBook.find(spellName);
        if (it != _spellBook.end())
            _spellBook.erase(it);
}
```
  - launchSpell / createSpell は若干量が多くなるため微妙かも